### PR TITLE
Fix/enable nut targets

### DIFF
--- a/molecule/install_from_pkgmgr/converge.yml
+++ b/molecule/install_from_pkgmgr/converge.yml
@@ -27,6 +27,8 @@
         - name: second_user
           password: insecure_password
           role: primary
+          instcmds:
+          - all
       nut_ups:
         - name: dummy_ups
           monitoruser: monitor

--- a/molecule/install_from_pkgmgr/converge.yml
+++ b/molecule/install_from_pkgmgr/converge.yml
@@ -28,7 +28,7 @@
           password: insecure_password
           role: primary
           instcmds:
-          - all
+            - all
       nut_ups:
         - name: dummy_ups
           monitoruser: monitor

--- a/molecule/install_from_pkgmgr/verify.yml
+++ b/molecule/install_from_pkgmgr/verify.yml
@@ -22,7 +22,7 @@
 
     - name: Assert upscmd for monitor user was denied
       ansible.builtin.assert:
-        that: 
+        that:
           - upscmd_result.rc == 1
           - "'ACCESS-DENIED' in upscmd_result.stderr"
 
@@ -39,7 +39,7 @@
 
     - name: Assert upscmd for monitor user was denied
       ansible.builtin.assert:
-        that: 
+        that:
           - upscmd_result.rc == 1
           - "'ACCESS-DENIED' in upscmd_result.stderr"
 

--- a/molecule/install_from_pkgmgr/verify.yml
+++ b/molecule/install_from_pkgmgr/verify.yml
@@ -1,5 +1,5 @@
 ---
-- name: Converge
+- name: Verify
   hosts: all
   gather_facts: true
   tasks:
@@ -13,19 +13,36 @@
       ansible.builtin.command:
         argv:
           - upscmd
-          - -a monitor
+          - -u monitor
           - -p changeme
           - dummy_ups
           - load.off
+      ignore_errors: true
+      register: upscmd_result
+
+    - name: Assert upscmd for monitor user was denied
+      ansible.builtin.assert:
+        that: 
+          - upscmd_result.rc == 1
+          - "'ACCESS-DENIED' in upscmd_result.stderr"
 
     - name: Perform command on dummy_ups2 with monitor user
       ansible.builtin.command:
         argv:
           - upscmd
-          - -a monitor
+          - -u monitor
           - -p changeme
           - dummy_ups2
           - load.off
+      ignore_errors: true
+      register: upscmd_result
+
+    - name: Assert upscmd for monitor user was denied
+      ansible.builtin.assert:
+        that: 
+          - upscmd_result.rc == 1
+          - "'ACCESS-DENIED' in upscmd_result.stderr"
+
     - name: Verify communication with dummy_ups2
       ansible.builtin.command:
         argv:
@@ -36,7 +53,7 @@
       ansible.builtin.command:
         argv:
           - upscmd
-          - -a second_user
+          - -u second_user
           - -p insecure_password
           - dummy_ups
           - load.off
@@ -45,7 +62,7 @@
       ansible.builtin.command:
         argv:
           - upscmd
-          - -a second_user
+          - -u second_user
           - -p insecure_password
           - dummy_ups2
           - load.off

--- a/molecule/install_from_source/converge.yml
+++ b/molecule/install_from_source/converge.yml
@@ -22,7 +22,9 @@
       nut_users:
         - name: monitor
           password: changeme
-          role: secondary
+          role: master
+          instcmds:
+            - all
       nut_ups:
         - name: dummy_ups
           monitoruser: monitor

--- a/molecule/install_from_source/verify.yml
+++ b/molecule/install_from_source/verify.yml
@@ -13,7 +13,7 @@
       ansible.builtin.command:
         argv:
           - upscmd
-          - -a monitor
+          - -u monitor
           - -p changeme
           - dummy_ups
           - load.off

--- a/molecule/switch_from_pkgmgr_to_source/converge.yml
+++ b/molecule/switch_from_pkgmgr_to_source/converge.yml
@@ -23,6 +23,8 @@
         - name: monitor
           password: changeme
           role: secondary
+          instcmds:
+            - all
       nut_ups:
         - name: dummy_ups
           monitoruser: monitor

--- a/molecule/switch_from_pkgmgr_to_source/verify.yml
+++ b/molecule/switch_from_pkgmgr_to_source/verify.yml
@@ -13,7 +13,7 @@
       ansible.builtin.command:
         argv:
           - upscmd
-          - -a monitor
+          - -u monitor
           - -p changeme
           - dummy_ups
           - load.off

--- a/molecule/switch_from_source_to_pkgmgr/converge.yml
+++ b/molecule/switch_from_source_to_pkgmgr/converge.yml
@@ -23,10 +23,12 @@
       nut_users:
         - name: monitor
           password: changeme
-          role: secondary
+          role: slave
         - name: second_user
           password: insecure_password
-          role: primary
+          role: master
+          instcmds:
+           - all
       nut_ups:
         - name: dummy_ups
           monitoruser: monitor

--- a/molecule/switch_from_source_to_pkgmgr/converge.yml
+++ b/molecule/switch_from_source_to_pkgmgr/converge.yml
@@ -28,7 +28,7 @@
           password: insecure_password
           role: master
           instcmds:
-           - all
+            - all
       nut_ups:
         - name: dummy_ups
           monitoruser: monitor

--- a/molecule/switch_from_source_to_pkgmgr/molecule.yml
+++ b/molecule/switch_from_source_to_pkgmgr/molecule.yml
@@ -2,8 +2,8 @@
 driver:
   name: docker
 platforms:
-  - name: "${MOLECULE_IMAGE:-debian12}"
-    image: "geerlingguy/docker-${MOLECULE_IMAGE:-debian12}-ansible:latest"
+  - name: "${MOLECULE_IMAGE:-debian11}"
+    image: "geerlingguy/docker-${MOLECULE_IMAGE:-debian11}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     cgroupns_mode: host

--- a/molecule/switch_from_source_to_pkgmgr/prepare.yml
+++ b/molecule/switch_from_source_to_pkgmgr/prepare.yml
@@ -1,7 +1,23 @@
 ---
-- name: Converge
+- name: Prepare
   hosts: all
   gather_facts: true
+  pre_tasks:
+    - name: Create NUT configuration folder.
+      ansible.builtin.file:
+        path: "/etc/nut"
+        state: directory
+        mode: '0755'
+    - name: Copy dummy-ups.dev file
+      ansible.builtin.copy:
+        src: "../dummy-ups.dev"
+        dest: "/etc/nut/dummy-ups.dev"
+        mode: '0755'
+    - name: Copy dummy-ups2.dev file
+      ansible.builtin.copy:
+        src: "../dummy-ups2.dev"
+        dest: "/etc/nut/dummy-ups2.dev"
+        mode: '0755'
   roles:
     - role: salvoxia.nut
       nut_install_from_source: false

--- a/molecule/switch_from_source_to_pkgmgr/verify.yml
+++ b/molecule/switch_from_source_to_pkgmgr/verify.yml
@@ -22,7 +22,7 @@
 
     - name: Assert upscmd for monitor user was denied
       ansible.builtin.assert:
-        that: 
+        that:
           - upscmd_result.rc == 1
           - "'ACCESS-DENIED' in upscmd_result.stderr"
 
@@ -39,7 +39,7 @@
 
     - name: Assert upscmd for monitor user was denied
       ansible.builtin.assert:
-        that: 
+        that:
           - upscmd_result.rc == 1
           - "'ACCESS-DENIED' in upscmd_result.stderr"
 

--- a/molecule/switch_from_source_to_pkgmgr/verify.yml
+++ b/molecule/switch_from_source_to_pkgmgr/verify.yml
@@ -1,5 +1,5 @@
 ---
-- name: Converge
+- name: Verify
   hosts: all
   gather_facts: true
   tasks:
@@ -13,19 +13,36 @@
       ansible.builtin.command:
         argv:
           - upscmd
-          - -a monitor
+          - -u monitor
           - -p changeme
           - dummy_ups
           - load.off
+      ignore_errors: true
+      register: upscmd_result
+
+    - name: Assert upscmd for monitor user was denied
+      ansible.builtin.assert:
+        that: 
+          - upscmd_result.rc == 1
+          - "'ACCESS-DENIED' in upscmd_result.stderr"
 
     - name: Perform command on dummy_ups2 with monitor user
       ansible.builtin.command:
         argv:
           - upscmd
-          - -a monitor
+          - -u monitor
           - -p changeme
           - dummy_ups2
           - load.off
+      ignore_errors: true
+      register: upscmd_result
+
+    - name: Assert upscmd for monitor user was denied
+      ansible.builtin.assert:
+        that: 
+          - upscmd_result.rc == 1
+          - "'ACCESS-DENIED' in upscmd_result.stderr"
+
     - name: Verify communication with dummy_ups2
       ansible.builtin.command:
         argv:
@@ -36,7 +53,7 @@
       ansible.builtin.command:
         argv:
           - upscmd
-          - -a second_user
+          - -u second_user
           - -p insecure_password
           - dummy_ups
           - load.off
@@ -45,7 +62,7 @@
       ansible.builtin.command:
         argv:
           - upscmd
-          - -a second_user
+          - -u second_user
           - -p insecure_password
           - dummy_ups2
           - load.off

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -56,8 +56,8 @@
           - item.name is defined and item.name | length > 0
           - item.password is defined and item.password | length > 0
           - item.role is defined
-          - item.role in ['primary', 'secondary']
-        fail_msg: "All users must have a non-empty name and password attribute, and role must be either primary or secondary!"
+          - item.role in ['primary', 'secondary', 'master', 'slave']
+        fail_msg: "All users must have a non-empty name and password attribute, and role must be either primary/master or secondary/slave!"
       with_items: "{{ nut_users }}"
 
     - name: Build list of user names

--- a/tasks/install_managed.yml
+++ b/tasks/install_managed.yml
@@ -7,20 +7,8 @@
   when: nut_installed_version is defined
 
 - name: Uninstall NUT from source
+  ansible.builtin.include_tasks: uninstall.yml
   when: "nut_installed_version is defined and ansible_facts.packages['nut-client'] is not defined or nut_state == 'absent'"
-  block:
-    - name: Set uninstall variables
-      ansible.builtin.set_fact:
-        nut_state: absent
-        nut_install_from_source: true
-
-    - name: Uninstall NUT from source
-      ansible.builtin.include_tasks: manage_install_from_source.yml
-
-    - name: Reset install variables
-      ansible.builtin.set_fact:
-        nut_state: present
-        nut_install_from_source: false
 
 - name: Ensure NUT packages are installed.
   ansible.builtin.package:

--- a/tasks/restart.yml
+++ b/tasks/restart.yml
@@ -7,5 +7,5 @@
   ansible.builtin.include_tasks: restart_service.yml
   loop_control:
     loop_var: service_name
-  loop: "{{ nut_services_installed | map(attribute='name') | list | difference(['nut-driver.service', 'nut-driver@.service']) }}"
+  loop: "{{ nut_services_installed | map(attribute='name') | list | difference(['nut-driver@.service']) }}"
   when: nut_enable_service

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -25,10 +25,26 @@
         state: started
         masked: false
         enabled: true
-      when: "nut_services is not undefined
-            and ansible_facts.services[item] is defined
-            and ansible_facts.services[item].status != 'running'"
+      when: 
+        - nut_services is not undefined
+        - ansible_facts.services[item] is defined
+        - ansible_facts.services[item].status != 'running'
       loop: "{{ nut_services }}"
+
+    - name: Enable nut.target
+      ansible.builtin.service:
+        name: "nut.target"
+        state: started
+        masked: false
+        enabled: true
+
+    - name: Enable nut-driver.target
+      ansible.builtin.service:
+        name: "{{ item }}"
+        state: started
+        masked: false
+        enabled: true
+      when: "'nut_server' in nut_services"
 
 - name: Disable and remove NUT services service
   when: nut_state == "absent" or not nut_enable_service

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -31,12 +31,28 @@
         - ansible_facts.services[item].status != 'running'
       loop: "{{ nut_services }}"
 
+    - name: Check for nut.target
+      ansible.builtin.command: "systemctl list-unit-files nut.target" # noqa: command-instead-of-module
+      register: nut_target_check
+      changed_when: false
+      ignore_errors: true
+
     - name: Enable nut.target
       ansible.builtin.service:
         name: "nut.target"
         state: started
         masked: false
         enabled: true
+      when: 
+        - nut_target_check.rc == 0
+    
+    - name: Check for nut-driver.target
+      ansible.builtin.command: "systemctl list-unit-files nut-driver.target" # noqa: command-instead-of-module
+      register: nut_driver_target_check
+      changed_when: false
+      ignore_errors: true
+      when:
+        - "'nut_server' in nut_services"
 
     - name: Enable nut-driver.target
       ansible.builtin.service:
@@ -44,7 +60,9 @@
         state: started
         masked: false
         enabled: true
-      when: "'nut_server' in nut_services"
+      when:
+        - "'nut_server' in nut_services"
+        - nut_driver_target_check.rc == 0
 
 - name: Disable and remove NUT services service
   when: nut_state == "absent" or not nut_enable_service

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -25,7 +25,7 @@
         state: started
         masked: false
         enabled: true
-      when: 
+      when:
         - nut_services is not undefined
         - ansible_facts.services[item] is defined
         - ansible_facts.services[item].status != 'running'

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -43,9 +43,9 @@
         state: started
         masked: false
         enabled: true
-      when: 
+      when:
         - nut_target_check.rc == 0
-    
+
     - name: Check for nut-driver.target
       ansible.builtin.command: "systemctl list-unit-files nut-driver.target" # noqa: command-instead-of-module
       register: nut_driver_target_check


### PR DESCRIPTION
Fix: When installing from source, systemd targets `nut.target` and `nut-driver.target` (for servers) was not enabled, causing the NUT services not to start upon reboot