### PR TITLE
fix: CI with Pyton 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.14'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible-lint ansible
+        run: pip3 install yamllint ansible-lint ansible-core>=2.20.0
 
       - name: Run yamllint.
         run: yamllint .
@@ -51,10 +51,10 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.14'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-plugins[docker]
+        run: pip3 install ansible-core>=2.20.0 molecule molecule-plugins[docker]
 
       - name: Install role dependencies.
         run: ansible-galaxy install -r requirements.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.14'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible-lint ansible
+        run: pip3 install yamllint ansible-lint ansible-core>=2.20.0
 
       - name: Run yamllint.
         run: yamllint .
@@ -52,10 +52,10 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.14'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-plugins[docker]
+        run: pip3 install ansible-core>=2.20.0 molecule molecule-plugins[docker]
 
       - name: Install role dependencies.
         run: ansible-galaxy install -r requirements.yml

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,4 +2,4 @@
 collections:
   - name: ansible.utils
   - name: ansible.netcommon
-  - name: community.general.make
+  - name: community.general

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,3 +2,4 @@
 collections:
   - name: ansible.utils
   - name: ansible.netcommon
+  - name: community.general.make

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
   - name: ansible.utils
+  - name: ansible.netcommon


### PR DESCRIPTION
- Explicitly require Python 3.14 for Github Runners
- Install `ansible-core` version >= 2.20.0 as required by Python 3.14 to Github Runners
